### PR TITLE
:+1: Add `isNonNullable`

### DIFF
--- a/is.ts
+++ b/is.ts
@@ -373,6 +373,23 @@ export function isNullish(x: unknown): x is null | undefined {
 }
 
 /**
+ * Return `true` if the type of `x` is not `null` or `undefined`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a = "a" as (string | null | undefined);
+ * if (isNonNullable(a)) {
+ *   // a is narrowed to string
+ *   const _: string = a;
+ * }
+ * ```
+ */
+export function isNonNullable<T>(x: T): x is NonNullable<T> {
+  return x != null;
+}
+
+/**
  * Return `true` if the type of `x` is `symbol`.
  *
  * ```ts
@@ -1629,6 +1646,7 @@ export const is = {
   LiteralOneOf: isLiteralOneOf,
   Map: isMap,
   MapOf: isMapOf,
+  NonNullable: isNonNullable,
   Null: isNull,
   Nullish: isNullish,
   Number: isNumber,


### PR DESCRIPTION
Add a predicate function that corresponds to Typescript's `NonNullable` utility type.

As you know, the argument of this function is generic type and is not `unknown`. So I'm not sure if it's allowed to include this in unknownutil.

I also considered adding the `isNonNullableOf()` function. However, I am concerned that it may be confusing with the `isUnwrapOptionalOf()` function.