### PR TITLE
:+1: Add `isParametersOf`

### DIFF
--- a/__snapshots__/is_test.ts.snap
+++ b/__snapshots__/is_test.ts.snap
@@ -70,6 +70,54 @@ snapshot[`isTupleOf<T, E> > returns properly named function 3`] = `
 ])"
 `;
 
+snapshot[`isParametersOf<T> > returns properly named function 1`] = `
+"isParametersOf([
+  isNumber,
+  isString,
+  isOptionalOf(isBoolean)
+])"
+`;
+
+snapshot[`isParametersOf<T> > returns properly named function 2`] = `"isParametersOf([(anonymous)])"`;
+
+snapshot[`isParametersOf<T> > returns properly named function 3`] = `"isParametersOf([])"`;
+
+snapshot[`isParametersOf<T> > returns properly named function 4`] = `
+"isParametersOf([
+  isParametersOf([
+    isParametersOf([
+      isNumber,
+      isString,
+      isOptionalOf(isBoolean)
+    ])
+  ])
+])"
+`;
+
+snapshot[`isParametersOf<T, E> > returns properly named function 1`] = `
+"isParametersOf([
+  isNumber,
+  isString,
+  isOptionalOf(isBoolean)
+], isArray)"
+`;
+
+snapshot[`isParametersOf<T, E> > returns properly named function 2`] = `"isParametersOf([(anonymous)], isArrayOf(isString))"`;
+
+snapshot[`isParametersOf<T, E> > returns properly named function 3`] = `"isParametersOf([], isArrayOf(isString))"`;
+
+snapshot[`isParametersOf<T, E> > returns properly named function 4`] = `
+"isParametersOf([
+  isParametersOf([
+    isParametersOf([
+      isNumber,
+      isString,
+      isOptionalOf(isBoolean)
+    ], isArray)
+  ], isArray)
+])"
+`;
+
 snapshot[`isReadonlyTupleOf<T> > returns properly named function 1`] = `
 "isReadonlyOf(isTupleOf([
   isNumber,

--- a/is.ts
+++ b/is.ts
@@ -754,20 +754,25 @@ type IsTupleOfMetadata = {
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `ParametersOf<T>` or `ParametersOf<T, E>`.
  *
- * This is similar to `TupleOf<T>` or `TupleOf<T, E>`, except that the `OptionalOf<P>` at the end of the tuple becomes optional.
+ * This is similar to `TupleOf<T>` or `TupleOf<T, E>`, but if `is.OptionalOf()` is specified at the trailing, the trailing elements becomes optional and makes variable-length tuple.
  *
  * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
  *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const isMyType = is.ParametersOf(
- *   [is.Number, is.String, is.OptionalOf(is.Boolean)] as const,
- * );
- * const a: unknown = [0, "a"];
+ * const isMyType = is.ParametersOf([
+ *   is.Number,
+ *   is.OptionalOf(is.String),
+ *   is.Boolean,
+ *   is.OptionalOf(is.Number),
+ *   is.OptionalOf(is.String),
+ *   is.OptionalOf(is.Boolean),
+ * ] as const);
+ * const a: unknown = [0, undefined, "a"];
  * if (isMyType(a)) {
- *   // a is narrowed to [number, string, boolean?]
- *   const _: [number, string, boolean?] = a;
+ *   // a is narrowed to [number, string | undefined, boolean, number?, string?, boolean?]
+ *   const _: [number, string | undefined, boolean, number?, string?, boolean?] = a;
  * }
  * ```
  *
@@ -777,7 +782,11 @@ type IsTupleOfMetadata = {
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
  * const isMyType = is.ParametersOf(
- *   [is.Number, is.OptionalOf(is.String), is.OptionalOf(is.Boolean)] as const,
+ *   [
+ *     is.Number,
+ *     is.OptionalOf(is.String),
+ *     is.OptionalOf(is.Boolean),
+ *   ] as const,
  *   is.ArrayOf(is.Number),
  * );
  * const a: unknown = [0, "a", true, 0, 1, 2];


### PR DESCRIPTION
## Motivation

I want to validate method arguments with optional parameters.

## Comparison with `isTupleOf()`

- `isTupleOf()`: the length of the tuple is fixed.

```ts
const a: unknown = ["a"];
if (is.TupleOf([is.String, is.Optional(is.Number)] as const)(a)) {
  // don't reach here
  const _: [string, number | undefined] = a;
}
```

- `isParametersOf()`: the tuple is truncated length if trailing predicates are optional.

```ts
const a: unknown = ["a"];
if (is.ParametersOf([is.String, is.Optional(is.Number)] as const)(a)) {
  // reach here
  const _: [string, number?] = a;
}
```

## Naming

If there is a better name, please suggest.