### PR TITLE
`isObjectOf` allows function object

### DIFF
--- a/is.ts
+++ b/is.ts
@@ -454,7 +454,7 @@ export function isOptionalOf<T>(
   }
   return Object.defineProperties(
     setPredicateFactoryMetadata(
-      (x: unknown): x is Predicate<T | undefined> => x === undefined || pred(x),
+      (x: unknown): x is T | undefined => x === undefined || pred(x),
       { name: "isOptionalOf", args: [pred] },
     ),
     { optional: { value: true as const } },

--- a/is.ts
+++ b/is.ts
@@ -1145,7 +1145,11 @@ export function isObjectOf<
   }
   return setPredicateFactoryMetadata(
     (x: unknown): x is ObjectOf<T> => {
-      if (x == null || typeof x !== "object" || Array.isArray(x)) return false;
+      if (
+        x == null ||
+        typeof x !== "object" && typeof x !== "function" ||
+        Array.isArray(x)
+      ) return false;
       // Check each values
       for (const k in predObj) {
         if (!predObj[k]((x as T)[k])) return false;

--- a/is_test.ts
+++ b/is_test.ts
@@ -1137,6 +1137,13 @@ Deno.test("isObjectOf<T>", async (t) => {
       true,
       "Object have an unknown property",
     );
+    assertEquals(
+      isObjectOf(predObj)(
+        Object.assign(() => void 0, { a: 0, b: "a", c: true }),
+      ),
+      true,
+      "Function object",
+    );
   });
   await t.step("returns false on non T object", () => {
     const predObj = {


### PR DESCRIPTION
Sometimes I want to use a function object with properties extended to it.