### PR TITLE
:+1: `isIntersectionOf` allows anything other than `isObjectOf`

### DIFF
--- a/__snapshots__/is_test.ts.snap
+++ b/__snapshots__/is_test.ts.snap
@@ -229,6 +229,17 @@ snapshot[`isIntersectionOf<T> > returns properly named function 1`] = `
 })"
 `;
 
+snapshot[`isIntersectionOf<T> > returns properly named function 2`] = `
+"isString"
+`;
+
+snapshot[`isIntersectionOf<T> > returns properly named function 3`] = `
+"isIntersectionOf([
+  isFunction,
+  isObjectOf({b: isString})
+])"
+`;
+
 snapshot[`isRequiredOf<T> > returns properly named function 1`] = `
 "isObjectOf({
   a: isNumber,

--- a/_typeutil.ts
+++ b/_typeutil.ts
@@ -2,9 +2,9 @@ export type FlatType<T> = T extends Record<PropertyKey, unknown>
   ? { [K in keyof T]: FlatType<T[K]> }
   : T;
 
-export type UnionToIntersection<U> =
-  (U extends unknown ? (k: U) => void : never) extends ((k: infer I) => void)
-    ? I
-    : never;
+export type TupleToIntersection<T> = T extends readonly [] ? never
+  : T extends readonly [infer U] ? U
+  : T extends readonly [infer U, ...infer R] ? U & TupleToIntersection<R>
+  : never;
 
 export type Writable<T> = { -readonly [P in keyof T]: T[P] };


### PR DESCRIPTION
Fixes #68

It's close to the functionality of the old `AllOf`.

## Questions

Allow only one element?

```ts
const isMyObj = is.IntersectionOf([
  is.ObjectOf({a: is.String}),
]);
```

Currently...

- The type allows only one or more elements.
- The implementation also works with 0 elements.
  - In that case, the Predicate will always return `true`.