### PR TITLE
feat[is]: `is*` functions allows symbol properties

### DIFF
--- a/__snapshots__/_inspect_test.ts.snap
+++ b/__snapshots__/_inspect_test.ts.snap
@@ -30,6 +30,24 @@ snapshot[`inspect > record 3`] = `
 
 snapshot[`inspect > record 4`] = `"{a: {b: {c: 0}}}"`;
 
+snapshot[`inspect > record 5`] = `"{Symbol(a): 0}"`;
+
+snapshot[`inspect > record 6`] = `
+"{
+  a: 0,
+  c: true,
+  Symbol(b): 1
+}"
+`;
+
+snapshot[`inspect > record 7`] = `
+"{
+  Symbol(a): {
+    Symbol(b): {Symbol(c): 0}
+  }
+}"
+`;
+
 snapshot[`inspect > function 1`] = `"inspect"`;
 
 snapshot[`inspect > function 2`] = `"(anonymous)"`;

--- a/_inspect.ts
+++ b/_inspect.ts
@@ -44,9 +44,8 @@ function inspectRecord(
   options: InspectOptions,
 ): string {
   const { threshold = defaultThreshold } = options;
-  const vs = Object.entries(value).map(([k, v]) =>
-    `${k}: ${inspect(v, options)}`
-  );
+  const vs = [...Object.keys(value), ...Object.getOwnPropertySymbols(value)]
+    .map((k) => `${k.toString()}: ${inspect(value[k], options)}`);
   const s = vs.join(", ");
   if (s.length <= threshold) return `{${s}}`;
   const m = vs.join(",\n");

--- a/_inspect_test.ts
+++ b/_inspect_test.ts
@@ -25,6 +25,12 @@ Deno.test("inspect", async (t) => {
     await assertSnapshot(t, inspect({ a: 0, b: 1, c: 2 }));
     await assertSnapshot(t, inspect({ a: "a", b: 1, c: true }));
     await assertSnapshot(t, inspect({ a: { b: { c: 0 } } }));
+    await assertSnapshot(t, inspect({ [Symbol("a")]: 0 }));
+    await assertSnapshot(t, inspect({ a: 0, [Symbol("b")]: 1, c: true }));
+    await assertSnapshot(
+      t,
+      inspect({ [Symbol("a")]: { [Symbol("b")]: { [Symbol("c")]: 0 } } }),
+    );
   });
   await t.step("function", async (t) => {
     await assertSnapshot(t, inspect(inspect));

--- a/is/__snapshots__/intersection_of_test.ts.snap
+++ b/is/__snapshots__/intersection_of_test.ts.snap
@@ -15,3 +15,19 @@ snapshot[`isIntersectionOf<T> > returns properly named predicate function 3`] = 
   isObjectOf({b: isString})
 ])"
 `;
+
+snapshot[`isIntersectionOf<T> > with symbol properties > returns properly named predicate function 1`] = `"isString"`;
+
+snapshot[`isIntersectionOf<T> > with symbol properties > returns properly named predicate function 2`] = `
+"isObjectOf({
+  a: isNumber,
+  Symbol(b): isString
+})"
+`;
+
+snapshot[`isIntersectionOf<T> > with symbol properties > returns properly named predicate function 3`] = `
+"isIntersectionOf([
+  isFunction,
+  isObjectOf({Symbol(b): isString})
+])"
+`;

--- a/is/__snapshots__/object_of_test.ts.snap
+++ b/is/__snapshots__/object_of_test.ts.snap
@@ -17,3 +17,19 @@ snapshot[`isObjectOf<T> > returns properly named predicate function 3`] = `
   })
 })"
 `;
+
+snapshot[`isObjectOf<T> > with symbol properties > returns properly named predicate function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  b: isString,
+  Symbol(s): isBoolean
+})"
+`;
+
+snapshot[`isObjectOf<T> > with symbol properties > returns properly named predicate function 2`] = `
+"isObjectOf({
+  Symbol(a): isObjectOf({
+    Symbol(b): isObjectOf({Symbol(c): isBoolean})
+  })
+})"
+`;

--- a/is/__snapshots__/omit_of_test.ts.snap
+++ b/is/__snapshots__/omit_of_test.ts.snap
@@ -8,3 +8,12 @@ snapshot[`isOmitOf<T, K> > returns properly named predicate function 1`] = `
 `;
 
 snapshot[`isOmitOf<T, K> > returns properly named predicate function 2`] = `"isObjectOf({a: isNumber})"`;
+
+snapshot[`isOmitOf<T, K> > with symbol properties > returns properly named predicate function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  Symbol(c): isBoolean
+})"
+`;
+
+snapshot[`isOmitOf<T, K> > with symbol properties > returns properly named predicate function 2`] = `"isObjectOf({a: isNumber})"`;

--- a/is/__snapshots__/parameters_of_test.ts.snap
+++ b/is/__snapshots__/parameters_of_test.ts.snap
@@ -24,7 +24,7 @@ snapshot[`isParametersOf<T> > returns properly named predicate function 4`] = `
 ])"
 `;
 
-snapshot[`isParametersOf<T, E> > returns properly named predicate function 1`] = `
+snapshot[`isParametersOf<T, R> > returns properly named predicate function 1`] = `
 "isParametersOf([
   isNumber,
   isString,
@@ -32,11 +32,11 @@ snapshot[`isParametersOf<T, E> > returns properly named predicate function 1`] =
 ], isArray)"
 `;
 
-snapshot[`isParametersOf<T, E> > returns properly named predicate function 2`] = `"isParametersOf([(anonymous)], isArrayOf(isString))"`;
+snapshot[`isParametersOf<T, R> > returns properly named predicate function 2`] = `"isParametersOf([(anonymous)], isArrayOf(isString))"`;
 
-snapshot[`isParametersOf<T, E> > returns properly named predicate function 3`] = `"isParametersOf([], isArrayOf(isString))"`;
+snapshot[`isParametersOf<T, R> > returns properly named predicate function 3`] = `"isParametersOf([], isArrayOf(isString))"`;
 
-snapshot[`isParametersOf<T, E> > returns properly named predicate function 4`] = `
+snapshot[`isParametersOf<T, R> > returns properly named predicate function 4`] = `
 "isParametersOf([
   isParametersOf([
     isParametersOf([

--- a/is/__snapshots__/partial_of_test.ts.snap
+++ b/is/__snapshots__/partial_of_test.ts.snap
@@ -23,3 +23,27 @@ snapshot[`isPartialOf<T> > returns properly named predicate function 2`] = `
   d: asOptional(asReadonly(isString))
 })"
 `;
+
+snapshot[`isPartialOf<T> > with symbol properties > returns properly named predicate function 1`] = `
+"isObjectOf({
+  a: asOptional(isNumber),
+  Symbol(b): asOptional(isUnionOf([
+    isString,
+    isUndefined
+  ])),
+  Symbol(c): asOptional(isBoolean),
+  Symbol(c): asOptional(asReadonly(isString))
+})"
+`;
+
+snapshot[`isPartialOf<T> > with symbol properties > returns properly named predicate function 2`] = `
+"isObjectOf({
+  a: asOptional(isNumber),
+  Symbol(b): asOptional(isUnionOf([
+    isString,
+    isUndefined
+  ])),
+  Symbol(c): asOptional(isBoolean),
+  Symbol(c): asOptional(asReadonly(isString))
+})"
+`;

--- a/is/__snapshots__/pick_of_test.ts.snap
+++ b/is/__snapshots__/pick_of_test.ts.snap
@@ -8,3 +8,12 @@ snapshot[`isPickOf<T, K> > returns properly named predicate function 1`] = `
 `;
 
 snapshot[`isPickOf<T, K> > returns properly named predicate function 2`] = `"isObjectOf({a: isNumber})"`;
+
+snapshot[`isPickOf<T, K> > with symbol properties > returns properly named predicate function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  Symbol(c): isBoolean
+})"
+`;
+
+snapshot[`isPickOf<T, K> > with symbol properties > returns properly named predicate function 2`] = `"isObjectOf({Symbol(c): isBoolean})"`;

--- a/is/__snapshots__/readonly_of_test.ts.snap
+++ b/is/__snapshots__/readonly_of_test.ts.snap
@@ -45,3 +45,25 @@ snapshot[`isReadonlyOf<T> > with isTupleOf > returns properly named predicate fu
 snapshot[`isReadonlyOf<T> > with isUniformTupleOf > returns properly named predicate function 1`] = `"isReadonlyOf(isUniformTupleOf(3, isNumber))"`;
 
 snapshot[`isReadonlyOf<T> > with isUniformTupleOf > returns properly named predicate function 2`] = `"isReadonlyOf(isUniformTupleOf(3, isNumber))"`;
+
+snapshot[`isReadonlyOf<T> > with symbol properties > with isObjectOf > returns properly named predicate function 1`] = `
+"isReadonlyOf(isObjectOf({
+  a: isNumber,
+  Symbol(b): isUnionOf([
+    isString,
+    isUndefined
+  ]),
+  Symbol(c): asReadonly(isBoolean)
+}))"
+`;
+
+snapshot[`isReadonlyOf<T> > with symbol properties > with isObjectOf > returns properly named predicate function 2`] = `
+"isReadonlyOf(isObjectOf({
+  a: isNumber,
+  Symbol(b): isUnionOf([
+    isString,
+    isUndefined
+  ]),
+  Symbol(c): asReadonly(isBoolean)
+}))"
+`;

--- a/is/__snapshots__/record_object_of_test.ts.snap
+++ b/is/__snapshots__/record_object_of_test.ts.snap
@@ -7,3 +7,7 @@ snapshot[`isRecordObjectOf<T> > returns properly named predicate function 2`] = 
 snapshot[`isRecordObjectOf<T, K> > returns properly named predicate function 1`] = `"isRecordObjectOf(isNumber, isString)"`;
 
 snapshot[`isRecordObjectOf<T, K> > returns properly named predicate function 2`] = `"isRecordObjectOf((anonymous), isString)"`;
+
+snapshot[`isRecordObjectOf<T, K> > with symbol properties > returns properly named predicate function 1`] = `"isRecordObjectOf(isNumber, isSymbol)"`;
+
+snapshot[`isRecordObjectOf<T, K> > with symbol properties > returns properly named predicate function 2`] = `"isRecordObjectOf((anonymous), isSymbol)"`;

--- a/is/__snapshots__/record_of_test.ts.snap
+++ b/is/__snapshots__/record_of_test.ts.snap
@@ -7,3 +7,7 @@ snapshot[`isRecordOf<T> > returns properly named predicate function 2`] = `"isRe
 snapshot[`isRecordOf<T, K> > returns properly named predicate function 1`] = `"isRecordOf(isNumber, isString)"`;
 
 snapshot[`isRecordOf<T, K> > returns properly named predicate function 2`] = `"isRecordOf((anonymous), isString)"`;
+
+snapshot[`isRecordOf<T, K> > with symbol properties > returns properly named predicate function 1`] = `"isRecordOf(isNumber, isSymbol)"`;
+
+snapshot[`isRecordOf<T, K> > with symbol properties > returns properly named predicate function 2`] = `"isRecordOf((anonymous), isSymbol)"`;

--- a/is/__snapshots__/required_of_test.ts.snap
+++ b/is/__snapshots__/required_of_test.ts.snap
@@ -23,3 +23,27 @@ snapshot[`isRequiredOf<T> > returns properly named predicate function 2`] = `
   d: asReadonly(isString)
 })"
 `;
+
+snapshot[`isRequiredOf<T> > with symbol properties > returns properly named predicate function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  Symbol(b): isUnionOf([
+    isString,
+    isUndefined
+  ]),
+  Symbol(c): isBoolean,
+  Symbol(d): asReadonly(isString)
+})"
+`;
+
+snapshot[`isRequiredOf<T> > with symbol properties > returns properly named predicate function 2`] = `
+"isObjectOf({
+  a: isNumber,
+  Symbol(b): isUnionOf([
+    isString,
+    isUndefined
+  ]),
+  Symbol(c): isBoolean,
+  Symbol(d): asReadonly(isString)
+})"
+`;

--- a/is/__snapshots__/strict_of_test.ts.snap
+++ b/is/__snapshots__/strict_of_test.ts.snap
@@ -17,3 +17,19 @@ snapshot[`isStrictOf<T> > returns properly named predicate function 3`] = `
   }))
 }))"
 `;
+
+snapshot[`isStrictOf<T> > with symbol properties > returns properly named predicate function 1`] = `
+"isStrictOf(isObjectOf({
+  a: isNumber,
+  Symbol(b): isString,
+  Symbol(c): isBoolean
+}))"
+`;
+
+snapshot[`isStrictOf<T> > with symbol properties > returns properly named predicate function 2`] = `
+"isStrictOf(isObjectOf({
+  a: isStrictOf(isObjectOf({
+    Symbol(b): isStrictOf(isObjectOf({Symbol(c): isBoolean}))
+  }))
+}))"
+`;

--- a/is/__snapshots__/tuple_of_test.ts.snap
+++ b/is/__snapshots__/tuple_of_test.ts.snap
@@ -22,7 +22,7 @@ snapshot[`isTupleOf<T> > returns properly named predicate function 3`] = `
 ])"
 `;
 
-snapshot[`isTupleOf<T, E> > returns properly named predicate function 1`] = `
+snapshot[`isTupleOf<T, R> > returns properly named predicate function 1`] = `
 "isTupleOf([
   isNumber,
   isString,
@@ -30,9 +30,9 @@ snapshot[`isTupleOf<T, E> > returns properly named predicate function 1`] = `
 ], isArray)"
 `;
 
-snapshot[`isTupleOf<T, E> > returns properly named predicate function 2`] = `"isTupleOf([(anonymous)], isArrayOf(isString))"`;
+snapshot[`isTupleOf<T, R> > returns properly named predicate function 2`] = `"isTupleOf([(anonymous)], isArrayOf(isString))"`;
 
-snapshot[`isTupleOf<T, E> > returns properly named predicate function 3`] = `
+snapshot[`isTupleOf<T, R> > returns properly named predicate function 3`] = `
 "isTupleOf([
   isTupleOf([
     isTupleOf([

--- a/is/intersection_of_test.ts
+++ b/is/intersection_of_test.ts
@@ -77,4 +77,79 @@ Deno.test("isIntersectionOf<T>", async (t) => {
       >(true);
     }
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const b = Symbol("b");
+    const objPreds = [
+      is.ObjectOf({ a: is.Number }),
+      is.ObjectOf({ [b]: is.String }),
+    ] as const;
+    const mixPreds = [
+      is.Function,
+      is.ObjectOf({ [b]: is.String }),
+    ] as const;
+
+    await t.step("returns properly named predicate function", async (t) => {
+      assertEquals(typeof isIntersectionOf([is.String]), "function");
+      await assertSnapshot(t, isIntersectionOf([is.String]).name);
+      await assertSnapshot(t, isIntersectionOf(objPreds).name);
+      await assertSnapshot(t, isIntersectionOf(mixPreds).name);
+    });
+
+    await t.step("returns true on all of T", () => {
+      const f = Object.assign(() => void 0, { [b]: "a" });
+      assertEquals(isIntersectionOf([is.String])("a"), true);
+      assertEquals(isIntersectionOf(objPreds)({ a: 0, [b]: "a" }), true);
+      assertEquals(isIntersectionOf(mixPreds)(f), true);
+    });
+
+    await t.step("returns false on non of T", () => {
+      const f = Object.assign(() => void 0, { [b]: "a" });
+      assertEquals(isIntersectionOf(objPreds)("a"), false);
+      assertEquals(isIntersectionOf(mixPreds)({ a: 0, [b]: "a" }), false);
+      assertEquals(isIntersectionOf([is.String])(f), false);
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = undefined;
+
+      if (isIntersectionOf([is.String])(a)) {
+        assertType<Equal<typeof a, string>>(true);
+      }
+
+      if (isIntersectionOf(objPreds)(a)) {
+        assertType<Equal<typeof a, { a: number } & { [b]: string }>>(true);
+      }
+
+      if (isIntersectionOf(mixPreds)(a)) {
+        assertType<
+          Equal<
+            typeof a,
+            & ((...args: unknown[]) => unknown)
+            & { [b]: string }
+          >
+        >(true);
+      }
+    });
+
+    await t.step("predicated type is correct (#68)", () => {
+      const a: unknown = undefined;
+      const pred = isIntersectionOf([
+        is.ObjectOf({ id: is.String }),
+        is.UnionOf([
+          is.ObjectOf({ result: is.String }),
+          is.ObjectOf({ error: is.String }),
+        ]),
+      ]);
+
+      if (pred(a)) {
+        assertType<
+          Equal<
+            typeof a,
+            { id: string } & ({ result: string } | { error: string })
+          >
+        >(true);
+      }
+    });
+  });
 });

--- a/is/mod.ts
+++ b/is/mod.ts
@@ -455,7 +455,7 @@ export const is: {
    * }
    * ```
    *
-   * With `predElse`:
+   * With `predRest` to represent rest parameters:
    *
    * ```ts
    * import { as, is } from "@core/unknownutil";
@@ -823,7 +823,7 @@ export const is: {
    */
   SyncFunction: typeof isSyncFunction;
   /**
-   * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>` or `TupleOf<T, E>`.
+   * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>` or `TupleOf<T, R>`.
    *
    * Use {@linkcode isUniformTupleOf} to check if the type of `x` is a tuple of uniform types.
    *
@@ -839,7 +839,7 @@ export const is: {
    * }
    * ```
    *
-   * With `predElse`:
+   * With `predRest` to represent rest elements:
    *
    * ```ts
    * import { is } from "@core/unknownutil";

--- a/is/object_of.ts
+++ b/is/object_of.ts
@@ -48,7 +48,10 @@ export function isObjectOf<
           Array.isArray(x)
         ) return false;
         // Check each values
-        return Object.keys(predObj).every((k) => predObj[k]((x as T)[k]));
+        return [
+          ...Object.keys(predObj),
+          ...Object.getOwnPropertySymbols(predObj),
+        ].every((k) => predObj[k]((x as T)[k]));
       },
       "isObjectOf",
       predObj,

--- a/is/omit_of.ts
+++ b/is/omit_of.ts
@@ -43,11 +43,11 @@ export function isOmitOf<
 ):
   & Predicate<FlatType<Omit<T, K>>>
   & IsPredObj<P> {
-  const s = new Set(keys);
-  const predObj = Object.fromEntries(
-    Object.entries(pred.predObj).filter(([k]) => !s.has(k as K)),
-  );
-  return isObjectOf(predObj) as
+  const predObj = { ...pred.predObj };
+  for (const key of keys) {
+    delete predObj[key];
+  }
+  return isObjectOf(predObj as Record<PropertyKey, Predicate<unknown>>) as
     & Predicate<FlatType<Omit<T, K>>>
     & IsPredObj<P>;
 }

--- a/is/parameters_of.ts
+++ b/is/parameters_of.ts
@@ -28,7 +28,7 @@ import { isArray } from "./array.ts";
  * }
  * ```
  *
- * With `predElse`:
+ * With `predRest` to represent rest parameters:
  *
  * ```ts
  * import { as, is } from "@core/unknownutil";
@@ -71,18 +71,18 @@ export function isParametersOf<
   E extends Predicate<unknown[]>,
 >(
   predTup: T,
-  predElse: E,
+  predRest: E,
 ): Predicate<[...ParametersOf<T>, ...PredicateType<E>]>;
 export function isParametersOf<
   T extends readonly [...Predicate<unknown>[]],
   E extends Predicate<unknown[]>,
 >(
   predTup: T,
-  predElse?: E,
+  predRest?: E,
 ): Predicate<ParametersOf<T> | [...ParametersOf<T>, ...PredicateType<E>]> {
   const requiresLength = 1 +
     predTup.findLastIndex((pred) => !hasOptional(pred));
-  if (!predElse) {
+  if (!predRest) {
     return rewriteName(
       (x: unknown): x is ParametersOf<T> => {
         if (
@@ -103,11 +103,11 @@ export function isParametersOf<
         }
         const head = x.slice(0, predTup.length);
         const tail = x.slice(predTup.length);
-        return predTup.every((pred, i) => pred(head[i])) && predElse(tail);
+        return predTup.every((pred, i) => pred(head[i])) && predRest(tail);
       },
       "isParametersOf",
       predTup,
-      predElse,
+      predRest,
     );
   }
 }

--- a/is/parameters_of_test.ts
+++ b/is/parameters_of_test.ts
@@ -59,7 +59,7 @@ Deno.test("isParametersOf<T>", async (t) => {
   });
 });
 
-Deno.test("isParametersOf<T, E>", async (t) => {
+Deno.test("isParametersOf<T, R>", async (t) => {
   await t.step("returns properly named predicate function", async (t) => {
     assertEquals(typeof isParametersOf([], is.Array), "function");
     await assertSnapshot(
@@ -92,32 +92,32 @@ Deno.test("isParametersOf<T, E>", async (t) => {
 
   await t.step("returns true on T tuple", () => {
     const predTup = [is.Number, is.String, as.Optional(is.Boolean)] as const;
-    const predElse = is.ArrayOf(is.Number);
+    const predRest = is.ArrayOf(is.Number);
     assertEquals(
-      isParametersOf(predTup, predElse)([0, "a", true, 0, 1, 2]),
+      isParametersOf(predTup, predRest)([0, "a", true, 0, 1, 2]),
       true,
     );
     assertEquals(
-      isParametersOf(predTup, predElse)([0, "a", undefined, 0, 1, 2]),
+      isParametersOf(predTup, predRest)([0, "a", undefined, 0, 1, 2]),
       true,
     );
-    assertEquals(isParametersOf(predTup, predElse)([0, "a"]), true);
+    assertEquals(isParametersOf(predTup, predRest)([0, "a"]), true);
   });
 
   await t.step("returns false on non T tuple", () => {
     const predTup = [is.Number, is.String, as.Optional(is.Boolean)] as const;
-    const predElse = is.ArrayOf(is.String);
-    assertEquals(isParametersOf(predTup, predElse)([0, 1, 2, 0, 1, 2]), false);
-    assertEquals(isParametersOf(predTup, predElse)([0, "a", 0, 1, 2]), false);
+    const predRest = is.ArrayOf(is.String);
+    assertEquals(isParametersOf(predTup, predRest)([0, 1, 2, 0, 1, 2]), false);
+    assertEquals(isParametersOf(predTup, predRest)([0, "a", 0, 1, 2]), false);
     assertEquals(
-      isParametersOf(predTup, predElse)([0, "a", true, 0, 1, 2]),
+      isParametersOf(predTup, predRest)([0, "a", true, 0, 1, 2]),
       false,
     );
     assertEquals(
-      isParametersOf(predTup, predElse)([0, "a", undefined, 0, 1, 2]),
+      isParametersOf(predTup, predRest)([0, "a", undefined, 0, 1, 2]),
       false,
     );
-    assertEquals(isParametersOf(predTup, predElse)([0, "a", "b"]), false);
+    assertEquals(isParametersOf(predTup, predRest)([0, "a", "b"]), false);
   });
 
   await t.step("predicated type is correct", () => {
@@ -127,9 +127,9 @@ Deno.test("isParametersOf<T, E>", async (t) => {
       as.Optional(is.String),
       as.Optional(is.Boolean),
     ] as const;
-    const predElse = is.ArrayOf(is.Number);
+    const predRest = is.ArrayOf(is.Number);
     const a: unknown = [0, "a"];
-    if (isParametersOf(predTup, predElse)(a)) {
+    if (isParametersOf(predTup, predRest)(a)) {
       assertType<
         Equal<
           typeof a,

--- a/is/partial_of.ts
+++ b/is/partial_of.ts
@@ -42,9 +42,14 @@ export function isPartialOf<
 ):
   & Predicate<FlatType<Partial<T>>>
   & IsPredObj<P> {
-  const predObj = Object.fromEntries(
-    Object.entries(pred.predObj).map(([k, v]) => [k, asOptional(v)]),
-  ) as Record<PropertyKey, Predicate<unknown>>;
+  const keys = [
+    ...Object.keys(pred.predObj),
+    ...Object.getOwnPropertySymbols(pred.predObj),
+  ];
+  const predObj: Record<PropertyKey, Predicate<unknown>> = { ...pred.predObj };
+  for (const key of keys) {
+    predObj[key] = asOptional(predObj[key]);
+  }
   return isObjectOf(predObj) as
     & Predicate<FlatType<Partial<T>>>
     & IsPredObj<P>;

--- a/is/partial_of_test.ts
+++ b/is/partial_of_test.ts
@@ -47,4 +47,55 @@ Deno.test("isPartialOf<T>", async (t) => {
       >(true);
     }
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const b = Symbol("b");
+    const c = Symbol("c");
+    const d = Symbol("c");
+    const pred = is.ObjectOf({
+      a: is.Number,
+      [b]: is.UnionOf([is.String, is.Undefined]),
+      [c]: as.Optional(is.Boolean),
+      [d]: as.Readonly(is.String),
+    });
+
+    await t.step("returns properly named predicate function", async (t) => {
+      await assertSnapshot(t, isPartialOf(pred).name);
+      await assertSnapshot(t, isPartialOf(isPartialOf(pred)).name);
+    });
+
+    await t.step("returns true on Partial<T> object", () => {
+      assertEquals(
+        isPartialOf(pred)({ a: undefined, [b]: undefined, [c]: undefined }),
+        true,
+      );
+      assertEquals(isPartialOf(pred)({}), true);
+    });
+
+    await t.step("returns false on non Partial<T> object", () => {
+      assertEquals(isPartialOf(pred)("a"), false, "Value is not an object");
+      assertEquals(
+        isPartialOf(pred)({ a: 0, [b]: "a", [c]: "" }),
+        false,
+        "Object have a different type property",
+      );
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = { a: 0, [b]: "a", [c]: true };
+      if (isPartialOf(pred)(a)) {
+        assertType<
+          Equal<
+            typeof a,
+            Partial<{
+              a: number;
+              [b]: string;
+              [c]: boolean;
+              readonly [d]: string;
+            }>
+          >
+        >(true);
+      }
+    });
+  });
 });

--- a/is/pick_of.ts
+++ b/is/pick_of.ts
@@ -43,11 +43,15 @@ export function isPickOf<
 ):
   & Predicate<FlatType<Pick<T, K>>>
   & IsPredObj<P> {
-  const s = new Set(keys);
-  const predObj = Object.fromEntries(
-    Object.entries(pred.predObj).filter(([k]) => s.has(k as K)),
-  );
-  return isObjectOf(predObj) as
+  const omitKeys = new Set([
+    ...Object.keys(pred.predObj),
+    ...Object.getOwnPropertySymbols(pred.predObj),
+  ]).difference(new Set(keys));
+  const predObj = { ...pred.predObj };
+  for (const key of omitKeys) {
+    delete predObj[key];
+  }
+  return isObjectOf(predObj as Record<PropertyKey, Predicate<unknown>>) as
     & Predicate<FlatType<Pick<T, K>>>
     & IsPredObj<P>;
 }

--- a/is/pick_of_test.ts
+++ b/is/pick_of_test.ts
@@ -51,4 +51,54 @@ Deno.test("isPickOf<T, K>", async (t) => {
       >(true);
     }
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const b = Symbol("b");
+    const c = Symbol("c");
+    const pred = is.ObjectOf({
+      a: is.Number,
+      [b]: is.String,
+      [c]: is.Boolean,
+    });
+
+    await t.step("returns properly named predicate function", async (t) => {
+      await assertSnapshot(t, isPickOf(pred, ["a", c]).name);
+      await assertSnapshot(t, isPickOf(isPickOf(pred, ["a", c]), [c]).name);
+    });
+
+    await t.step("returns true on Pick<T, K> object", () => {
+      assertEquals(
+        isPickOf(pred, ["a", c])({ a: 0, [b]: undefined, [c]: true }),
+        true,
+      );
+      assertEquals(isPickOf(pred, ["a"])({ a: 0 }), true);
+    });
+
+    await t.step("returns false on non Pick<T, K> object", () => {
+      assertEquals(
+        isPickOf(pred, ["a", c])("a"),
+        false,
+        "Value is not an object",
+      );
+      assertEquals(
+        isPickOf(pred, ["a", c])({ a: 0, [b]: "a", [c]: "" }),
+        false,
+        "Object have a different type property",
+      );
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = { a: 0, [b]: "a", [c]: true };
+      if (isPickOf(pred, ["a", c])(a)) {
+        assertType<
+          Equal<typeof a, { a: number; [c]: boolean }>
+        >(true);
+      }
+      if (isPickOf(isPickOf(pred, ["a", c]), ["a"])(a)) {
+        assertType<
+          Equal<typeof a, { a: number }>
+        >(true);
+      }
+    });
+  });
 });

--- a/is/readonly_of_test.ts
+++ b/is/readonly_of_test.ts
@@ -170,4 +170,52 @@ Deno.test("isReadonlyOf<T>", async (t) => {
       }
     });
   });
+
+  await t.step("with symbol properties", async (t) => {
+    await t.step("with isObjectOf", async (t) => {
+      const b = Symbol("b");
+      const c = Symbol("c");
+      const pred = is.ObjectOf({
+        a: is.Number,
+        [b]: is.UnionOf([is.String, is.Undefined]),
+        [c]: as.Readonly(is.Boolean),
+      });
+      await t.step("returns properly named predicate function", async (t) => {
+        await assertSnapshot(t, isReadonlyOf(pred).name);
+        await assertSnapshot(t, isReadonlyOf(isReadonlyOf(pred)).name);
+      });
+
+      await t.step("returns true on Readonly<T> object", () => {
+        assertEquals(
+          isReadonlyOf(pred)({ a: 0, [b]: "b", [c]: true } as const),
+          true,
+        );
+        assertEquals(
+          isReadonlyOf(pred)({ a: 0, [b]: "b", [c]: true }),
+          true,
+        );
+      });
+
+      await t.step("returns false on non Readonly<T> object", () => {
+        assertEquals(isReadonlyOf(pred)("a"), false, "Value is not an object");
+        assertEquals(
+          isReadonlyOf(pred)({ a: 0, [b]: "a", [c]: "" }),
+          false,
+          "Object have a different type property",
+        );
+      });
+
+      await t.step("predicated type is correct", () => {
+        const a: unknown = { a: 0, [b]: "a", [c]: true };
+        if (isReadonlyOf(pred)(a)) {
+          assertType<
+            Equal<
+              typeof a,
+              Readonly<{ a: number; [b]: string | undefined; [c]: boolean }>
+            >
+          >(true);
+        }
+      });
+    });
+  });
 });

--- a/is/record_object_of.ts
+++ b/is/record_object_of.ts
@@ -39,7 +39,10 @@ export function isRecordObjectOf<T, K extends PropertyKey = PropertyKey>(
   return rewriteName(
     (x: unknown): x is Record<K, T> => {
       if (!isRecordObject(x)) return false;
-      const keys = Object.keys(x);
+      const keys = [
+        ...Object.keys(x),
+        ...Object.getOwnPropertySymbols(x),
+      ];
       for (const k of keys) {
         if (!pred(x[k])) return false;
         if (predKey && !predKey(k)) return false;

--- a/is/record_object_of.ts
+++ b/is/record_object_of.ts
@@ -39,7 +39,8 @@ export function isRecordObjectOf<T, K extends PropertyKey = PropertyKey>(
   return rewriteName(
     (x: unknown): x is Record<K, T> => {
       if (!isRecordObject(x)) return false;
-      for (const k in x) {
+      const keys = Object.keys(x);
+      for (const k of keys) {
         if (!pred(x[k])) return false;
         if (predKey && !predKey(k)) return false;
       }

--- a/is/record_object_of_test.ts
+++ b/is/record_object_of_test.ts
@@ -52,6 +52,21 @@ Deno.test("isRecordObjectOf<T>", async (t) => {
       );
     });
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const a = Symbol("a");
+    await t.step("returns true on T record", () => {
+      assertEquals(isRecordObjectOf(is.Number)({ [a]: 0 }), true);
+      assertEquals(isRecordObjectOf(is.String)({ [a]: "a" }), true);
+      assertEquals(isRecordObjectOf(is.Boolean)({ [a]: true }), true);
+    });
+
+    await t.step("returns false on non T record", () => {
+      assertEquals(isRecordObjectOf(is.String)({ [a]: 0 }), false);
+      assertEquals(isRecordObjectOf(is.Number)({ [a]: "a" }), false);
+      assertEquals(isRecordObjectOf(is.String)({ [a]: true }), false);
+    });
+  });
 });
 
 Deno.test("isRecordObjectOf<T, K>", async (t) => {
@@ -89,6 +104,7 @@ Deno.test("isRecordObjectOf<T, K>", async (t) => {
   });
 
   await t.step("checks only object's own properties", async (t) => {
+    const s = Symbol("s");
     await t.step("returns true on T record", () => {
       assertEquals(
         isRecordObjectOf(is.Number, is.String)(
@@ -115,6 +131,58 @@ Deno.test("isRecordObjectOf<T, K>", async (t) => {
         true,
         "No own properties",
       );
+      assertEquals(
+        isRecordObjectOf(is.String, is.String)(
+          Object.assign(Object.create({ [s]: "ignore" }), {/* empty */}),
+        ),
+        true,
+        "No own properties",
+      );
+    });
+  });
+
+  await t.step("with symbol properties", async (t) => {
+    const a = Symbol("a");
+    await t.step("returns properly named predicate function", async (t) => {
+      await assertSnapshot(t, isRecordObjectOf(is.Number, is.Symbol).name);
+      await assertSnapshot(
+        t,
+        isRecordObjectOf((_x): _x is string => false, is.Symbol).name,
+      );
+    });
+
+    await t.step("returns true on T record", () => {
+      assertEquals(isRecordObjectOf(is.Number, is.Symbol)({ [a]: 0 }), true);
+      assertEquals(isRecordObjectOf(is.String, is.Symbol)({ [a]: "a" }), true);
+      assertEquals(
+        isRecordObjectOf(is.Boolean, is.Symbol)({ [a]: true }),
+        true,
+      );
+    });
+
+    await t.step("returns false on non T record", () => {
+      assertEquals(isRecordObjectOf(is.String, is.Symbol)({ [a]: 0 }), false);
+      assertEquals(isRecordObjectOf(is.Number, is.Symbol)({ [a]: "a" }), false);
+      assertEquals(
+        isRecordObjectOf(is.String, is.Symbol)({ [a]: true }),
+        false,
+      );
+    });
+
+    await t.step("returns false on non K record", () => {
+      assertEquals(isRecordObjectOf(is.Number, is.String)({ [a]: 0 }), false);
+      assertEquals(isRecordObjectOf(is.String, is.String)({ [a]: "a" }), false);
+      assertEquals(
+        isRecordObjectOf(is.Boolean, is.String)({ [a]: true }),
+        false,
+      );
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = { a: 0 };
+      if (isRecordObjectOf(is.Number, is.Symbol)(a)) {
+        assertType<Equal<typeof a, Record<symbol, number>>>(true);
+      }
     });
   });
 });

--- a/is/record_object_of_test.ts
+++ b/is/record_object_of_test.ts
@@ -29,6 +29,29 @@ Deno.test("isRecordObjectOf<T>", async (t) => {
       assertType<Equal<typeof a, Record<PropertyKey, number>>>(true);
     }
   });
+
+  await t.step("checks only object's own properties", async (t) => {
+    await t.step("returns true on T record", () => {
+      assertEquals(
+        isRecordObjectOf(is.Number)(
+          Object.assign(Object.create({ p: "ignore" }), { a: 0 }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.String)(
+          Object.assign(Object.create({ p: 0 /* ignore */ }), { a: "a" }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.Boolean)(
+          Object.assign(Object.create({ p: "ignore" }), { a: true }),
+        ),
+        true,
+      );
+    });
+  });
 });
 
 Deno.test("isRecordObjectOf<T, K>", async (t) => {
@@ -63,5 +86,35 @@ Deno.test("isRecordObjectOf<T, K>", async (t) => {
     if (isRecordObjectOf(is.Number, is.String)(a)) {
       assertType<Equal<typeof a, Record<string, number>>>(true);
     }
+  });
+
+  await t.step("checks only object's own properties", async (t) => {
+    await t.step("returns true on T record", () => {
+      assertEquals(
+        isRecordObjectOf(is.Number, is.String)(
+          Object.assign(Object.create({ p: "ignore" }), { a: 0 }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.String, is.String)(
+          Object.assign(Object.create({ p: 0 /* ignore */ }), { a: "a" }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.Boolean, is.String)(
+          Object.assign(Object.create({ p: "ignore" }), { a: true }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.String, is.Number)(
+          Object.assign(Object.create({ p: "ignore" }), {/* empty */}),
+        ),
+        true,
+        "No own properties",
+      );
+    });
   });
 });

--- a/is/record_of.ts
+++ b/is/record_of.ts
@@ -39,7 +39,10 @@ export function isRecordOf<T, K extends PropertyKey = PropertyKey>(
   return rewriteName(
     (x: unknown): x is Record<K, T> => {
       if (!isRecord(x)) return false;
-      const keys = Object.keys(x);
+      const keys = [
+        ...Object.keys(x),
+        ...Object.getOwnPropertySymbols(x),
+      ];
       for (const k of keys) {
         if (!pred(x[k])) return false;
         if (predKey && !predKey(k)) return false;

--- a/is/record_of.ts
+++ b/is/record_of.ts
@@ -39,7 +39,8 @@ export function isRecordOf<T, K extends PropertyKey = PropertyKey>(
   return rewriteName(
     (x: unknown): x is Record<K, T> => {
       if (!isRecord(x)) return false;
-      for (const k in x) {
+      const keys = Object.keys(x);
+      for (const k of keys) {
         if (!pred(x[k])) return false;
         if (predKey && !predKey(k)) return false;
       }

--- a/is/record_of_test.ts
+++ b/is/record_of_test.ts
@@ -52,6 +52,21 @@ Deno.test("isRecordOf<T>", async (t) => {
       );
     });
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const a = Symbol("a");
+    await t.step("returns true on T record", () => {
+      assertEquals(isRecordOf(is.Number)({ [a]: 0 }), true);
+      assertEquals(isRecordOf(is.String)({ [a]: "a" }), true);
+      assertEquals(isRecordOf(is.Boolean)({ [a]: true }), true);
+    });
+
+    await t.step("returns false on non T record", () => {
+      assertEquals(isRecordOf(is.String)({ [a]: 0 }), false);
+      assertEquals(isRecordOf(is.Number)({ [a]: "a" }), false);
+      assertEquals(isRecordOf(is.String)({ [a]: true }), false);
+    });
+  });
 });
 
 Deno.test("isRecordOf<T, K>", async (t) => {
@@ -89,6 +104,7 @@ Deno.test("isRecordOf<T, K>", async (t) => {
   });
 
   await t.step("checks only object's own properties", async (t) => {
+    const s = Symbol("s");
     await t.step("returns true on T record", () => {
       assertEquals(
         isRecordOf(is.Number, is.String)(
@@ -115,6 +131,49 @@ Deno.test("isRecordOf<T, K>", async (t) => {
         true,
         "No own properties",
       );
+      assertEquals(
+        isRecordOf(is.String, is.String)(
+          Object.assign(Object.create({ [s]: "ignore" }), {/* empty */}),
+        ),
+        true,
+        "No own properties",
+      );
+    });
+  });
+
+  await t.step("with symbol properties", async (t) => {
+    const a = Symbol("a");
+    await t.step("returns properly named predicate function", async (t) => {
+      await assertSnapshot(t, isRecordOf(is.Number, is.Symbol).name);
+      await assertSnapshot(
+        t,
+        isRecordOf((_x): _x is string => false, is.Symbol).name,
+      );
+    });
+
+    await t.step("returns true on T record", () => {
+      assertEquals(isRecordOf(is.Number, is.Symbol)({ [a]: 0 }), true);
+      assertEquals(isRecordOf(is.String, is.Symbol)({ [a]: "a" }), true);
+      assertEquals(isRecordOf(is.Boolean, is.Symbol)({ [a]: true }), true);
+    });
+
+    await t.step("returns false on non T record", () => {
+      assertEquals(isRecordOf(is.String, is.Symbol)({ [a]: 0 }), false);
+      assertEquals(isRecordOf(is.Number, is.Symbol)({ [a]: "a" }), false);
+      assertEquals(isRecordOf(is.String, is.Symbol)({ [a]: true }), false);
+    });
+
+    await t.step("returns false on non K record", () => {
+      assertEquals(isRecordOf(is.Number, is.String)({ [a]: 0 }), false);
+      assertEquals(isRecordOf(is.String, is.String)({ [a]: "a" }), false);
+      assertEquals(isRecordOf(is.Boolean, is.String)({ [a]: true }), false);
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = { a: 0 };
+      if (isRecordOf(is.Number, is.Symbol)(a)) {
+        assertType<Equal<typeof a, Record<symbol, number>>>(true);
+      }
     });
   });
 });

--- a/is/record_of_test.ts
+++ b/is/record_of_test.ts
@@ -29,6 +29,29 @@ Deno.test("isRecordOf<T>", async (t) => {
       assertType<Equal<typeof a, Record<PropertyKey, number>>>(true);
     }
   });
+
+  await t.step("checks only object's own properties", async (t) => {
+    await t.step("returns true on T record", () => {
+      assertEquals(
+        isRecordOf(is.Number)(
+          Object.assign(Object.create({ p: "ignore" }), { a: 0 }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordOf(is.String)(
+          Object.assign(Object.create({ p: 0 /* ignore */ }), { a: "a" }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordOf(is.Boolean)(
+          Object.assign(Object.create({ p: "ignore" }), { a: true }),
+        ),
+        true,
+      );
+    });
+  });
 });
 
 Deno.test("isRecordOf<T, K>", async (t) => {
@@ -63,5 +86,35 @@ Deno.test("isRecordOf<T, K>", async (t) => {
     if (isRecordOf(is.Number, is.String)(a)) {
       assertType<Equal<typeof a, Record<string, number>>>(true);
     }
+  });
+
+  await t.step("checks only object's own properties", async (t) => {
+    await t.step("returns true on T record", () => {
+      assertEquals(
+        isRecordOf(is.Number, is.String)(
+          Object.assign(Object.create({ p: "ignore" }), { a: 0 }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordOf(is.String, is.String)(
+          Object.assign(Object.create({ p: 0 /* ignore */ }), { a: "a" }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordOf(is.Boolean, is.String)(
+          Object.assign(Object.create({ p: "ignore" }), { a: true }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordOf(is.String, is.Number)(
+          Object.assign(Object.create({ p: "ignore" }), {/* empty */}),
+        ),
+        true,
+        "No own properties",
+      );
+    });
   });
 });

--- a/is/required_of.ts
+++ b/is/required_of.ts
@@ -42,9 +42,14 @@ export function isRequiredOf<
 ):
   & Predicate<FlatType<Required<T>>>
   & IsPredObj<P> {
-  const predObj = Object.fromEntries(
-    Object.entries(pred.predObj).map(([k, v]) => [k, asUnoptional(v)]),
-  );
+  const keys = [
+    ...Object.keys(pred.predObj),
+    ...Object.getOwnPropertySymbols(pred.predObj),
+  ];
+  const predObj: Record<PropertyKey, Predicate<unknown>> = { ...pred.predObj };
+  for (const key of keys) {
+    predObj[key] = asUnoptional(predObj[key]);
+  }
   return isObjectOf(predObj) as
     & Predicate<FlatType<Required<T>>>
     & IsPredObj<P>;

--- a/is/required_of_test.ts
+++ b/is/required_of_test.ts
@@ -51,4 +51,59 @@ Deno.test("isRequiredOf<T>", async (t) => {
       >(true);
     }
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const b = Symbol("b");
+    const c = Symbol("c");
+    const d = Symbol("d");
+    const pred = is.ObjectOf({
+      a: is.Number,
+      [b]: is.UnionOf([is.String, is.Undefined]),
+      [c]: as.Optional(is.Boolean),
+      [d]: as.Readonly(is.String),
+    });
+    await t.step("returns properly named predicate function", async (t) => {
+      await assertSnapshot(t, isRequiredOf(pred).name);
+      await assertSnapshot(t, isRequiredOf(isRequiredOf(pred)).name);
+    });
+
+    await t.step("returns true on Required<T> object", () => {
+      assertEquals(
+        isRequiredOf(pred)({ a: undefined, [b]: undefined, [c]: undefined }),
+        false,
+        "Object does not have required properties",
+      );
+      assertEquals(
+        isRequiredOf(pred)({}),
+        false,
+        "Object does not have required properties",
+      );
+    });
+
+    await t.step("returns false on non Required<T> object", () => {
+      assertEquals(isRequiredOf(pred)("a"), false, "Value is not an object");
+      assertEquals(
+        isRequiredOf(pred)({ a: 0, [b]: "a", [c]: "" }),
+        false,
+        "Object have a different type property",
+      );
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = { a: 0, [b]: "a", [c]: true };
+      if (isRequiredOf(pred)(a)) {
+        assertType<
+          Equal<
+            typeof a,
+            {
+              a: number;
+              [b]: string | undefined;
+              [c]: boolean;
+              readonly [d]: string;
+            }
+          >
+        >(true);
+      }
+    });
+  });
 });

--- a/is/required_of_test.ts
+++ b/is/required_of_test.ts
@@ -19,24 +19,30 @@ Deno.test("isRequiredOf<T>", async (t) => {
   });
 
   await t.step("returns true on Required<T> object", () => {
+    assertEquals(isRequiredOf(pred)({ a: 0, b: "a", c: true, d: "a" }), true);
     assertEquals(
-      isRequiredOf(pred)({ a: undefined, b: undefined, c: undefined }),
-      false,
-      "Object does not have required properties",
-    );
-    assertEquals(
-      isRequiredOf(pred)({}),
-      false,
-      "Object does not have required properties",
+      isRequiredOf(pred)({ a: 0, b: undefined, c: true, d: "a" }),
+      true,
+      "Union type contains 'undefined'",
     );
   });
 
   await t.step("returns false on non Required<T> object", () => {
     assertEquals(isRequiredOf(pred)("a"), false, "Value is not an object");
     assertEquals(
-      isRequiredOf(pred)({ a: 0, b: "a", c: "" }),
+      isRequiredOf(pred)({ a: 0, b: "a", c: 0, d: "a" }),
       false,
       "Object have a different type property",
+    );
+    assertEquals(
+      isRequiredOf(pred)({ a: 0, b: "a", d: "a" }),
+      false,
+      "Object does not have required properties",
+    );
+    assertEquals(
+      isRequiredOf(pred)({ a: 0, b: "a", c: undefined, d: "a" }),
+      false,
+      "Optional property that converted to required is 'undefined'",
     );
   });
 
@@ -69,23 +75,32 @@ Deno.test("isRequiredOf<T>", async (t) => {
 
     await t.step("returns true on Required<T> object", () => {
       assertEquals(
-        isRequiredOf(pred)({ a: undefined, [b]: undefined, [c]: undefined }),
-        false,
-        "Object does not have required properties",
+        isRequiredOf(pred)({ a: 0, [b]: "a", [c]: true, [d]: "a" }),
+        true,
       );
       assertEquals(
-        isRequiredOf(pred)({}),
-        false,
-        "Object does not have required properties",
+        isRequiredOf(pred)({ a: 0, [b]: undefined, [c]: true, [d]: "a" }),
+        true,
+        "Union type contains 'undefined'",
       );
     });
 
     await t.step("returns false on non Required<T> object", () => {
       assertEquals(isRequiredOf(pred)("a"), false, "Value is not an object");
       assertEquals(
-        isRequiredOf(pred)({ a: 0, [b]: "a", [c]: "" }),
+        isRequiredOf(pred)({ a: 0, [b]: "a", [c]: 0, [d]: "a" }),
         false,
         "Object have a different type property",
+      );
+      assertEquals(
+        isRequiredOf(pred)({ a: 0, [b]: "a", [d]: "a" }),
+        false,
+        "Object does not have required properties",
+      );
+      assertEquals(
+        isRequiredOf(pred)({ a: 0, [b]: "a", [c]: undefined, [d]: "a" }),
+        false,
+        "Optional property that converted to required is 'undefined'",
       );
     });
 

--- a/is/strict_of.ts
+++ b/is/strict_of.ts
@@ -40,15 +40,18 @@ export function isStrictOf<
 ):
   & Predicate<T>
   & IsPredObj<P> {
-  const s = new Set(Object.keys(pred.predObj));
+  const s = new Set(getKeys(pred.predObj));
   return rewriteName(
     (x: unknown): x is T => {
       if (!pred(x)) return false;
-      // deno-lint-ignore no-explicit-any
-      const ks = Object.keys(x as any);
-      return ks.length <= s.size && ks.every((k) => s.has(k));
+      const ks = new Set(getKeys(x));
+      return ks.difference(s).size === 0;
     },
     "isStrictOf",
     pred,
   ) as Predicate<T> & IsPredObj<P>;
+}
+
+function getKeys(o: Record<PropertyKey, unknown>) {
+  return [...Object.keys(o), ...Object.getOwnPropertySymbols(o)];
 }

--- a/is/strict_of_test.ts
+++ b/is/strict_of_test.ts
@@ -155,4 +155,112 @@ Deno.test("isStrictOf<T>", async (t) => {
       }
     });
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const b = Symbol("b");
+    const c = Symbol("c");
+    const predObj = {
+      a: is.Number,
+      [b]: is.UnionOf([is.String, is.Undefined]),
+      [c]: as.Optional(is.Boolean),
+    };
+    await t.step("returns properly named predicate function", async (t) => {
+      await assertSnapshot(
+        t,
+        isStrictOf(
+          is.ObjectOf({ a: is.Number, [b]: is.String, [c]: is.Boolean }),
+        )
+          .name,
+      );
+      await assertSnapshot(
+        t,
+        isStrictOf(
+          is.ObjectOf({
+            a: isStrictOf(
+              is.ObjectOf({
+                [b]: isStrictOf(is.ObjectOf({ [c]: is.Boolean })),
+              }),
+            ),
+          }),
+        ).name,
+      );
+    });
+
+    await t.step("returns true on T object", () => {
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({ a: 0, [b]: "a", [c]: true }),
+        true,
+      );
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({ a: 0, [b]: "a" }),
+        true,
+        "Object does not have an optional property",
+      );
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({ a: 0, [b]: "a", [c]: undefined }),
+        true,
+        "Object has `undefined` as value of optional property",
+      );
+    });
+
+    await t.step("returns false on non T object", () => {
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({ a: 0, [b]: "a", [c]: "" }),
+        false,
+        "Object have a different type property",
+      );
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({ a: 0, [b]: "a", [c]: null }),
+        false,
+        "Object has `null` as value of optional property",
+      );
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({
+          a: 0,
+          [b]: "a",
+          [c]: true,
+          d: "invalid",
+        }),
+        false,
+        "Object have an unknown property",
+      );
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({
+          a: 0,
+          [b]: "a",
+          [c]: true,
+          [Symbol("d")]: "invalid",
+        }),
+        false,
+        "Object have an unknown symbol property",
+      );
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({
+          a: 0,
+          [b]: "a",
+          d: "invalid",
+        }),
+        false,
+        "Object have the same number of properties but an unknown property exists",
+      );
+      assertEquals(
+        isStrictOf(is.ObjectOf(predObj))({
+          a: 0,
+          [b]: "a",
+          [Symbol("d")]: "invalid",
+        }),
+        false,
+        "Object have the same number of properties but an unknown symbol property exists",
+      );
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = { a: 0, [b]: "a" };
+      if (isStrictOf(is.ObjectOf(predObj))(a)) {
+        assertType<
+          Equal<typeof a, { a: number; [b]: string | undefined; [c]?: boolean }>
+        >(true);
+      }
+    });
+  });
 });

--- a/is/tuple_of.ts
+++ b/is/tuple_of.ts
@@ -3,7 +3,7 @@ import type { Predicate, PredicateType } from "../type.ts";
 import { isArray } from "./array.ts";
 
 /**
- * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>` or `TupleOf<T, E>`.
+ * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>` or `TupleOf<T, R>`.
  *
  * Use {@linkcode isUniformTupleOf} to check if the type of `x` is a tuple of uniform types.
  *
@@ -19,7 +19,7 @@ import { isArray } from "./array.ts";
  * }
  * ```
  *
- * With `predElse`:
+ * With `predRest` to represent rest elements:
  *
  * ```ts
  * import { is } from "@core/unknownutil";
@@ -56,20 +56,20 @@ export function isTupleOf<
 
 export function isTupleOf<
   T extends readonly [Predicate<unknown>, ...Predicate<unknown>[]],
-  E extends Predicate<unknown[]>,
+  R extends Predicate<unknown[]>,
 >(
   predTup: T,
-  predElse: E,
-): Predicate<[...TupleOf<T>, ...PredicateType<E>]>;
+  predRest: R,
+): Predicate<[...TupleOf<T>, ...PredicateType<R>]>;
 
 export function isTupleOf<
   T extends readonly [Predicate<unknown>, ...Predicate<unknown>[]],
-  E extends Predicate<unknown[]>,
+  R extends Predicate<unknown[]>,
 >(
   predTup: T,
-  predElse?: E,
-): Predicate<TupleOf<T> | [...TupleOf<T>, ...PredicateType<E>]> {
-  if (!predElse) {
+  predRest?: R,
+): Predicate<TupleOf<T> | [...TupleOf<T>, ...PredicateType<R>]> {
+  if (!predRest) {
     return rewriteName(
       (x: unknown): x is TupleOf<T> => {
         if (!isArray(x) || x.length !== predTup.length) {
@@ -82,17 +82,17 @@ export function isTupleOf<
     );
   } else {
     return rewriteName(
-      (x: unknown): x is [...TupleOf<T>, ...PredicateType<E>] => {
+      (x: unknown): x is [...TupleOf<T>, ...PredicateType<R>] => {
         if (!isArray(x) || x.length < predTup.length) {
           return false;
         }
         const head = x.slice(0, predTup.length);
         const tail = x.slice(predTup.length);
-        return predTup.every((pred, i) => pred(head[i])) && predElse(tail);
+        return predTup.every((pred, i) => pred(head[i])) && predRest(tail);
       },
       "isTupleOf",
       predTup,
-      predElse,
+      predRest,
     );
   }
 }

--- a/is/tuple_of_test.ts
+++ b/is/tuple_of_test.ts
@@ -43,7 +43,7 @@ Deno.test("isTupleOf<T>", async (t) => {
   });
 });
 
-Deno.test("isTupleOf<T, E>", async (t) => {
+Deno.test("isTupleOf<T, R>", async (t) => {
   await t.step("returns properly named predicate function", async (t) => {
     await assertSnapshot(
       t,
@@ -67,27 +67,27 @@ Deno.test("isTupleOf<T, E>", async (t) => {
 
   await t.step("returns true on T tuple", () => {
     const predTup = [is.Number, is.String, is.Boolean] as const;
-    const predElse = is.ArrayOf(is.Number);
-    assertEquals(isTupleOf(predTup, predElse)([0, "a", true, 0, 1, 2]), true);
+    const predRest = is.ArrayOf(is.Number);
+    assertEquals(isTupleOf(predTup, predRest)([0, "a", true, 0, 1, 2]), true);
   });
 
   await t.step("returns false on non T tuple", () => {
     const predTup = [is.Number, is.String, is.Boolean] as const;
-    const predElse = is.ArrayOf(is.String);
-    assertEquals(isTupleOf(predTup, predElse)([0, 1, 2, 0, 1, 2]), false);
-    assertEquals(isTupleOf(predTup, predElse)([0, "a", 0, 1, 2]), false);
+    const predRest = is.ArrayOf(is.String);
+    assertEquals(isTupleOf(predTup, predRest)([0, 1, 2, 0, 1, 2]), false);
+    assertEquals(isTupleOf(predTup, predRest)([0, "a", 0, 1, 2]), false);
     assertEquals(
-      isTupleOf(predTup, predElse)([0, "a", true, 0, 0, 1, 2]),
+      isTupleOf(predTup, predRest)([0, "a", true, 0, 0, 1, 2]),
       false,
     );
-    assertEquals(isTupleOf(predTup, predElse)([0, "a", true, 0, 1, 2]), false);
+    assertEquals(isTupleOf(predTup, predRest)([0, "a", true, 0, 1, 2]), false);
   });
 
   await t.step("predicated type is correct", () => {
     const predTup = [is.Number, is.String, is.Boolean] as const;
-    const predElse = is.ArrayOf(is.Number);
+    const predRest = is.ArrayOf(is.Number);
     const a: unknown = [0, "a", true, 0, 1, 2];
-    if (isTupleOf(predTup, predElse)(a)) {
+    if (isTupleOf(predTup, predRest)(a)) {
       assertType<Equal<typeof a, [number, string, boolean, ...number[]]>>(
         true,
       );


### PR DESCRIPTION
Implements to these functions:

- [x] inspect
- [x] isIntersectionOf
- [x] isObjectOf
- [x] isOmitOf
- [x] isPartialOf
- [x] isPickOf
- [x] isReadonlyOf (Maybe not necessary)
- [x] isRecordObjectOf
- [x] isRecordOf
- [x] isRequiredOf
- [x] isStrictOf

Refs #94, #95