### PR TITLE
feat[inspect]: inspects record with symbol properties

### DIFF
--- a/__snapshots__/_inspect_test.ts.snap
+++ b/__snapshots__/_inspect_test.ts.snap
@@ -30,6 +30,24 @@ snapshot[`inspect > record 3`] = `
 
 snapshot[`inspect > record 4`] = `"{a: {b: {c: 0}}}"`;
 
+snapshot[`inspect > record 5`] = `"{Symbol(a): 0}"`;
+
+snapshot[`inspect > record 6`] = `
+"{
+  a: 0,
+  c: true,
+  Symbol(b): 1
+}"
+`;
+
+snapshot[`inspect > record 7`] = `
+"{
+  Symbol(a): {
+    Symbol(b): {Symbol(c): 0}
+  }
+}"
+`;
+
 snapshot[`inspect > function 1`] = `"inspect"`;
 
 snapshot[`inspect > function 2`] = `"(anonymous)"`;

--- a/_inspect.ts
+++ b/_inspect.ts
@@ -44,9 +44,8 @@ function inspectRecord(
   options: InspectOptions,
 ): string {
   const { threshold = defaultThreshold } = options;
-  const vs = Object.entries(value).map(([k, v]) =>
-    `${k}: ${inspect(v, options)}`
-  );
+  const vs = [...Object.keys(value), ...Object.getOwnPropertySymbols(value)]
+    .map((k) => `${k.toString()}: ${inspect(value[k], options)}`);
   const s = vs.join(", ");
   if (s.length <= threshold) return `{${s}}`;
   const m = vs.join(",\n");

--- a/_inspect_test.ts
+++ b/_inspect_test.ts
@@ -25,6 +25,12 @@ Deno.test("inspect", async (t) => {
     await assertSnapshot(t, inspect({ a: 0, b: 1, c: 2 }));
     await assertSnapshot(t, inspect({ a: "a", b: 1, c: true }));
     await assertSnapshot(t, inspect({ a: { b: { c: 0 } } }));
+    await assertSnapshot(t, inspect({ [Symbol("a")]: 0 }));
+    await assertSnapshot(t, inspect({ a: 0, [Symbol("b")]: 1, c: true }));
+    await assertSnapshot(
+      t,
+      inspect({ [Symbol("a")]: { [Symbol("b")]: { [Symbol("c")]: 0 } } }),
+    );
   });
   await t.step("function", async (t) => {
     await assertSnapshot(t, inspect(inspect));


### PR DESCRIPTION
Note that there is no way to get the string keys and symbol keys in order, so we first enumerate the string keys, then the symbol keys.