### PR TITLE
fix: remove `is/mod` from `deno.jsonc`

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -24,7 +24,6 @@
     "./is/literal-one-of": "./is/literal_one_of.ts",
     "./is/map": "./is/map.ts",
     "./is/map-of": "./is/map_of.ts",
-    "./is/mod": "./is/mod.ts",
     "./is/null": "./is/null.ts",
     "./is/nullish": "./is/nullish.ts",
     "./is/number": "./is/number.ts",


### PR DESCRIPTION
Close #91