### PR TITLE
feat[isRecordObjectOf]: checks own symbol key properties

### DIFF
--- a/is/__snapshots__/record_object_of_test.ts.snap
+++ b/is/__snapshots__/record_object_of_test.ts.snap
@@ -7,3 +7,7 @@ snapshot[`isRecordObjectOf<T> > returns properly named predicate function 2`] = 
 snapshot[`isRecordObjectOf<T, K> > returns properly named predicate function 1`] = `"isRecordObjectOf(isNumber, isString)"`;
 
 snapshot[`isRecordObjectOf<T, K> > returns properly named predicate function 2`] = `"isRecordObjectOf((anonymous), isString)"`;
+
+snapshot[`isRecordObjectOf<T, K> > with symbol properties > returns properly named predicate function 1`] = `"isRecordObjectOf(isNumber, isSymbol)"`;
+
+snapshot[`isRecordObjectOf<T, K> > with symbol properties > returns properly named predicate function 2`] = `"isRecordObjectOf((anonymous), isSymbol)"`;

--- a/is/record_object_of.ts
+++ b/is/record_object_of.ts
@@ -39,7 +39,10 @@ export function isRecordObjectOf<T, K extends PropertyKey = PropertyKey>(
   return rewriteName(
     (x: unknown): x is Record<K, T> => {
       if (!isRecordObject(x)) return false;
-      const keys = Object.keys(x);
+      const keys = [
+        ...Object.keys(x),
+        ...Object.getOwnPropertySymbols(x),
+      ];
       for (const k of keys) {
         if (!pred(x[k])) return false;
         if (predKey && !predKey(k)) return false;

--- a/is/record_object_of.ts
+++ b/is/record_object_of.ts
@@ -39,7 +39,8 @@ export function isRecordObjectOf<T, K extends PropertyKey = PropertyKey>(
   return rewriteName(
     (x: unknown): x is Record<K, T> => {
       if (!isRecordObject(x)) return false;
-      for (const k in x) {
+      const keys = Object.keys(x);
+      for (const k of keys) {
         if (!pred(x[k])) return false;
         if (predKey && !predKey(k)) return false;
       }

--- a/is/record_object_of_test.ts
+++ b/is/record_object_of_test.ts
@@ -52,6 +52,21 @@ Deno.test("isRecordObjectOf<T>", async (t) => {
       );
     });
   });
+
+  await t.step("with symbol properties", async (t) => {
+    const a = Symbol("a");
+    await t.step("returns true on T record", () => {
+      assertEquals(isRecordObjectOf(is.Number)({ [a]: 0 }), true);
+      assertEquals(isRecordObjectOf(is.String)({ [a]: "a" }), true);
+      assertEquals(isRecordObjectOf(is.Boolean)({ [a]: true }), true);
+    });
+
+    await t.step("returns false on non T record", () => {
+      assertEquals(isRecordObjectOf(is.String)({ [a]: 0 }), false);
+      assertEquals(isRecordObjectOf(is.Number)({ [a]: "a" }), false);
+      assertEquals(isRecordObjectOf(is.String)({ [a]: true }), false);
+    });
+  });
 });
 
 Deno.test("isRecordObjectOf<T, K>", async (t) => {
@@ -89,6 +104,7 @@ Deno.test("isRecordObjectOf<T, K>", async (t) => {
   });
 
   await t.step("checks only object's own properties", async (t) => {
+    const s = Symbol("s");
     await t.step("returns true on T record", () => {
       assertEquals(
         isRecordObjectOf(is.Number, is.String)(
@@ -115,6 +131,58 @@ Deno.test("isRecordObjectOf<T, K>", async (t) => {
         true,
         "No own properties",
       );
+      assertEquals(
+        isRecordObjectOf(is.String, is.String)(
+          Object.assign(Object.create({ [s]: "ignore" }), {/* empty */}),
+        ),
+        true,
+        "No own properties",
+      );
+    });
+  });
+
+  await t.step("with symbol properties", async (t) => {
+    const a = Symbol("a");
+    await t.step("returns properly named predicate function", async (t) => {
+      await assertSnapshot(t, isRecordObjectOf(is.Number, is.Symbol).name);
+      await assertSnapshot(
+        t,
+        isRecordObjectOf((_x): _x is string => false, is.Symbol).name,
+      );
+    });
+
+    await t.step("returns true on T record", () => {
+      assertEquals(isRecordObjectOf(is.Number, is.Symbol)({ [a]: 0 }), true);
+      assertEquals(isRecordObjectOf(is.String, is.Symbol)({ [a]: "a" }), true);
+      assertEquals(
+        isRecordObjectOf(is.Boolean, is.Symbol)({ [a]: true }),
+        true,
+      );
+    });
+
+    await t.step("returns false on non T record", () => {
+      assertEquals(isRecordObjectOf(is.String, is.Symbol)({ [a]: 0 }), false);
+      assertEquals(isRecordObjectOf(is.Number, is.Symbol)({ [a]: "a" }), false);
+      assertEquals(
+        isRecordObjectOf(is.String, is.Symbol)({ [a]: true }),
+        false,
+      );
+    });
+
+    await t.step("returns false on non K record", () => {
+      assertEquals(isRecordObjectOf(is.Number, is.String)({ [a]: 0 }), false);
+      assertEquals(isRecordObjectOf(is.String, is.String)({ [a]: "a" }), false);
+      assertEquals(
+        isRecordObjectOf(is.Boolean, is.String)({ [a]: true }),
+        false,
+      );
+    });
+
+    await t.step("predicated type is correct", () => {
+      const a: unknown = { a: 0 };
+      if (isRecordObjectOf(is.Number, is.Symbol)(a)) {
+        assertType<Equal<typeof a, Record<symbol, number>>>(true);
+      }
     });
   });
 });

--- a/is/record_object_of_test.ts
+++ b/is/record_object_of_test.ts
@@ -29,6 +29,29 @@ Deno.test("isRecordObjectOf<T>", async (t) => {
       assertType<Equal<typeof a, Record<PropertyKey, number>>>(true);
     }
   });
+
+  await t.step("checks only object's own properties", async (t) => {
+    await t.step("returns true on T record", () => {
+      assertEquals(
+        isRecordObjectOf(is.Number)(
+          Object.assign(Object.create({ p: "ignore" }), { a: 0 }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.String)(
+          Object.assign(Object.create({ p: 0 /* ignore */ }), { a: "a" }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.Boolean)(
+          Object.assign(Object.create({ p: "ignore" }), { a: true }),
+        ),
+        true,
+      );
+    });
+  });
 });
 
 Deno.test("isRecordObjectOf<T, K>", async (t) => {
@@ -63,5 +86,35 @@ Deno.test("isRecordObjectOf<T, K>", async (t) => {
     if (isRecordObjectOf(is.Number, is.String)(a)) {
       assertType<Equal<typeof a, Record<string, number>>>(true);
     }
+  });
+
+  await t.step("checks only object's own properties", async (t) => {
+    await t.step("returns true on T record", () => {
+      assertEquals(
+        isRecordObjectOf(is.Number, is.String)(
+          Object.assign(Object.create({ p: "ignore" }), { a: 0 }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.String, is.String)(
+          Object.assign(Object.create({ p: 0 /* ignore */ }), { a: "a" }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.Boolean, is.String)(
+          Object.assign(Object.create({ p: "ignore" }), { a: true }),
+        ),
+        true,
+      );
+      assertEquals(
+        isRecordObjectOf(is.String, is.Number)(
+          Object.assign(Object.create({ p: "ignore" }), {/* empty */}),
+        ),
+        true,
+        "No own properties",
+      );
+    });
   });
 });


### PR DESCRIPTION
Contains bug fixes. See below comments.