### PR TITLE
feat[isTupleOf]: add overloads to leading/middle rest elements

### DIFF
--- a/is/__snapshots__/tuple_of_test.ts.snap
+++ b/is/__snapshots__/tuple_of_test.ts.snap
@@ -44,6 +44,28 @@ snapshot[`isTupleOf<T, R> > returns properly named predicate function 3`] = `
 ])"
 `;
 
+snapshot[`isTupleOf<R, T> > returns properly named predicate function 1`] = `
+"isTupleOf(isArray, [
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isTupleOf<R, T> > returns properly named predicate function 2`] = `"isTupleOf(isArrayOf(isString), [(anonymous)])"`;
+
+snapshot[`isTupleOf<R, T> > returns properly named predicate function 3`] = `
+"isTupleOf([
+  isTupleOf(isArray, [
+    isTupleOf(isArray, [
+      isNumber,
+      isString,
+      isBoolean
+    ])
+  ])
+])"
+`;
+
 snapshot[`isTupleOf<T, R, L> > returns properly named predicate function 1`] = `
 "isTupleOf([
   isNumber,

--- a/is/__snapshots__/tuple_of_test.ts.snap
+++ b/is/__snapshots__/tuple_of_test.ts.snap
@@ -43,3 +43,35 @@ snapshot[`isTupleOf<T, R> > returns properly named predicate function 3`] = `
   ], isArray)
 ])"
 `;
+
+snapshot[`isTupleOf<T, R, L> > returns properly named predicate function 1`] = `
+"isTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+], isArray, [
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isTupleOf<T, R, L> > returns properly named predicate function 2`] = `"isTupleOf([(anonymous)], isArrayOf(isString), [(anonymous)])"`;
+
+snapshot[`isTupleOf<T, R, L> > returns properly named predicate function 3`] = `
+"isTupleOf([
+  isTupleOf([
+    isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ], isArray)
+  ], isArray, [
+    isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ], isArray)
+  ])
+])"
+`;

--- a/is/__snapshots__/tuple_of_test.ts.snap
+++ b/is/__snapshots__/tuple_of_test.ts.snap
@@ -39,7 +39,7 @@ snapshot[`isTupleOf<T, R> > returns properly named predicate function 3`] = `
       isNumber,
       isString,
       isBoolean
-    ], isArray)
+    ], isArrayOf(isString))
   ], isArray)
 ])"
 `;
@@ -57,7 +57,7 @@ snapshot[`isTupleOf<R, T> > returns properly named predicate function 2`] = `"is
 snapshot[`isTupleOf<R, T> > returns properly named predicate function 3`] = `
 "isTupleOf([
   isTupleOf(isArray, [
-    isTupleOf(isArray, [
+    isTupleOf(isArrayOf(isString), [
       isNumber,
       isString,
       isBoolean
@@ -72,9 +72,9 @@ snapshot[`isTupleOf<T, R, L> > returns properly named predicate function 1`] = `
   isString,
   isBoolean
 ], isArray, [
-  isNumber,
   isString,
-  isBoolean
+  isBoolean,
+  isNumber
 ])"
 `;
 
@@ -87,13 +87,21 @@ snapshot[`isTupleOf<T, R, L> > returns properly named predicate function 3`] = `
       isNumber,
       isString,
       isBoolean
-    ], isArray)
+    ], isArrayOf(isString), [
+      isString,
+      isBoolean,
+      isNumber
+    ])
   ], isArray, [
     isTupleOf([
       isNumber,
       isString,
       isBoolean
-    ], isArray)
+    ], isArrayOf(isNumber), [
+      isNumber,
+      isBoolean,
+      isString
+    ])
   ])
 ])"
 `;

--- a/is/mod.ts
+++ b/is/mod.ts
@@ -823,7 +823,7 @@ export const is: {
    */
   SyncFunction: typeof isSyncFunction;
   /**
-   * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>` or `TupleOf<T, R>`.
+   * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>`.
    *
    * Use {@linkcode isUniformTupleOf} to check if the type of `x` is a tuple of uniform types.
    *
@@ -839,7 +839,7 @@ export const is: {
    * }
    * ```
    *
-   * With `predRest` to represent rest elements:
+   * With `predRest` to represent rest elements or leading rest elements:
    *
    * ```ts
    * import { is } from "@core/unknownutil";
@@ -851,6 +851,30 @@ export const is: {
    * const a: unknown = [0, "a", true, 0, 1, 2];
    * if (isMyType(a)) {
    *   const _: [number, string, boolean, ...number[]] = a;
+   * }
+   *
+   * const isMyTypeLeadingRest = is.TupleOf(
+   *   is.ArrayOf(is.Number),
+   *   [is.Number, is.String, is.Boolean],
+   * );
+   * if (isMyTypeLeadingRest(a)) {
+   *   const _: [...number[], number, string, boolean] = a;
+   * }
+   * ```
+   *
+   * With `predRest` and `predTrail` to represent middle rest elements:
+   *
+   * ```ts
+   * import { is } from "@core/unknownutil";
+   *
+   * const isMyType = is.TupleOf(
+   *   [is.Number, is.String, is.Boolean],
+   *   is.ArrayOf(is.Number),
+   *   [is.Number, is.String, is.Boolean],
+   * );
+   * const a: unknown = [0, "a", true, 0, 1, 2, 0, "a", true];
+   * if (isMyType(a)) {
+   *   const _: [number, string, boolean, ...number[], number, string, boolean] = a;
    * }
    * ```
    *

--- a/is/tuple_of.ts
+++ b/is/tuple_of.ts
@@ -86,9 +86,8 @@ export function isTupleOf<
         if (!isArray(x) || x.length < predTup.length) {
           return false;
         }
-        const head = x.slice(0, predTup.length);
-        const tail = x.slice(predTup.length);
-        return predTup.every((pred, i) => pred(head[i])) && predRest(tail);
+        const rest = x.slice(predTup.length);
+        return predTup.every((pred, i) => pred(x[i])) && predRest(rest);
       },
       "isTupleOf",
       predTup,

--- a/is/tuple_of.ts
+++ b/is/tuple_of.ts
@@ -3,7 +3,7 @@ import type { Predicate, PredicateType } from "../type.ts";
 import { isArray } from "./array.ts";
 
 /**
- * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>` or `TupleOf<T, R>`.
+ * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>`.
  *
  * Use {@linkcode isUniformTupleOf} to check if the type of `x` is a tuple of uniform types.
  *

--- a/is/tuple_of.ts
+++ b/is/tuple_of.ts
@@ -126,9 +126,9 @@ export function isTupleOf<
         if (!isArray(x) || x.length < predTup.length) {
           return false;
         }
-        const rest = x.slice(0, -predTup.length);
-        const trail = x.slice(-predTup.length);
-        return predTup.every((pred, i) => pred(trail[i])) && predRest(rest);
+        const offset = x.length - predTup.length;
+        return predTup.every((pred, i) => pred(x[offset + i])) &&
+          predRest(x.slice(0, offset));
       },
       "isTupleOf",
       predRest,
@@ -154,8 +154,8 @@ export function isTupleOf<
         if (!isArray(x) || x.length < predTup.length) {
           return false;
         }
-        const rest = x.slice(predTup.length);
-        return predTup.every((pred, i) => pred(x[i])) && predRest(rest);
+        return predTup.every((pred, i) => pred(x[i])) &&
+          predRest(x.slice(predTup.length));
       },
       "isTupleOf",
       predTup,
@@ -169,11 +169,10 @@ export function isTupleOf<
         if (!isArray(x) || x.length < (predTup.length + predTrail.length)) {
           return false;
         }
-        const rest = x.slice(predTup.length, -predTrail.length);
-        const trail = x.slice(-predTrail.length);
+        const offset = x.length - predTrail.length;
         return predTup.every((pred, i) => pred(x[i])) &&
-          predTrail.every((pred, i) => pred(trail[i])) &&
-          predRest(rest);
+          predTrail.every((pred, i) => pred(x[offset + i])) &&
+          predRest(x.slice(predTup.length, offset));
       },
       "isTupleOf",
       predTup,

--- a/is/tuple_of.ts
+++ b/is/tuple_of.ts
@@ -102,7 +102,7 @@ export function isTupleOf<
   predTup: T,
   predRest: R,
   predTrail: L,
-): Predicate<[...TupleOf<T>, ...PredicateType<R>, ...TupleOf<T>]>;
+): Predicate<[...TupleOf<T>, ...PredicateType<R>, ...TupleOf<L>]>;
 
 export function isTupleOf<
   T extends readonly [Predicate<unknown>, ...Predicate<unknown>[]],
@@ -116,7 +116,7 @@ export function isTupleOf<
   | TupleOf<T>
   | [...TupleOf<T>, ...PredicateType<R>]
   | [...PredicateType<R>, ...TupleOf<T>]
-  | [...TupleOf<T>, ...PredicateType<R>, ...TupleOf<T>]
+  | [...TupleOf<T>, ...PredicateType<R>, ...TupleOf<L>]
 > {
   if (typeof predTupOrRest === "function") {
     const predRest = predTupOrRest as R;
@@ -163,7 +163,9 @@ export function isTupleOf<
     );
   } else {
     return rewriteName(
-      (x: unknown): x is [...TupleOf<T>, ...PredicateType<R>] => {
+      (
+        x: unknown,
+      ): x is [...TupleOf<T>, ...PredicateType<R>, ...TupleOf<L>] => {
         if (!isArray(x) || x.length < (predTup.length + predTrail.length)) {
           return false;
         }

--- a/is/tuple_of_test.ts
+++ b/is/tuple_of_test.ts
@@ -17,8 +17,11 @@ Deno.test("isTupleOf<T>", async (t) => {
     );
     await assertSnapshot(
       t,
-      isTupleOf([isTupleOf([isTupleOf([is.Number, is.String, is.Boolean])])])
-        .name,
+      isTupleOf([
+        isTupleOf([
+          isTupleOf([is.Number, is.String, is.Boolean]),
+        ]),
+      ]).name,
     );
   });
 
@@ -51,14 +54,21 @@ Deno.test("isTupleOf<T, R>", async (t) => {
     );
     await assertSnapshot(
       t,
-      isTupleOf([(_x): _x is string => false], is.ArrayOf(is.String))
-        .name,
+      isTupleOf(
+        [(_x): _x is string => false],
+        is.ArrayOf(is.String),
+      ).name,
     );
     await assertSnapshot(
       t,
       isTupleOf([
         isTupleOf(
-          [isTupleOf([is.Number, is.String, is.Boolean], is.Array)],
+          [
+            isTupleOf(
+              [is.Number, is.String, is.Boolean],
+              is.Array,
+            ),
+          ],
           is.Array,
         ),
       ]).name,
@@ -123,8 +133,10 @@ Deno.test("isTupleOf<R, T>", async (t) => {
     );
     await assertSnapshot(
       t,
-      isTupleOf(is.ArrayOf(is.String), [(_x): _x is string => false])
-        .name,
+      isTupleOf(
+        is.ArrayOf(is.String),
+        [(_x): _x is string => false],
+      ).name,
     );
     await assertSnapshot(
       t,
@@ -191,26 +203,37 @@ Deno.test("isTupleOf<T, R, L>", async (t) => {
   await t.step("returns properly named predicate function", async (t) => {
     await assertSnapshot(
       t,
-      isTupleOf([is.Number, is.String, is.Boolean], is.Array, [
-        is.Number,
-        is.String,
-        is.Boolean,
-      ]).name,
+      isTupleOf(
+        [is.Number, is.String, is.Boolean],
+        is.Array,
+        [is.Number, is.String, is.Boolean],
+      ).name,
     );
     await assertSnapshot(
       t,
-      isTupleOf([(_x): _x is string => false], is.ArrayOf(is.String), [
-        (_x): _x is string => false,
-      ])
-        .name,
+      isTupleOf(
+        [(_x): _x is string => false],
+        is.ArrayOf(is.String),
+        [(_x): _x is string => false],
+      ).name,
     );
     await assertSnapshot(
       t,
       isTupleOf([
         isTupleOf(
-          [isTupleOf([is.Number, is.String, is.Boolean], is.Array)],
+          [
+            isTupleOf(
+              [is.Number, is.String, is.Boolean],
+              is.Array,
+            ),
+          ],
           is.Array,
-          [isTupleOf([is.Number, is.String, is.Boolean], is.Array)],
+          [
+            isTupleOf(
+              [is.Number, is.String, is.Boolean],
+              is.Array,
+            ),
+          ],
         ),
       ]).name,
     );

--- a/is/tuple_of_test.ts
+++ b/is/tuple_of_test.ts
@@ -68,19 +68,39 @@ Deno.test("isTupleOf<T, R>", async (t) => {
   await t.step("returns true on T tuple", () => {
     const predTup = [is.Number, is.String, is.Boolean] as const;
     const predRest = is.ArrayOf(is.Number);
+    assertEquals(isTupleOf(predTup, predRest)([0, "a", true]), true);
     assertEquals(isTupleOf(predTup, predRest)([0, "a", true, 0, 1, 2]), true);
   });
 
   await t.step("returns false on non T tuple", () => {
     const predTup = [is.Number, is.String, is.Boolean] as const;
     const predRest = is.ArrayOf(is.String);
-    assertEquals(isTupleOf(predTup, predRest)([0, 1, 2, 0, 1, 2]), false);
-    assertEquals(isTupleOf(predTup, predRest)([0, "a", 0, 1, 2]), false);
+    assertEquals(isTupleOf(predTup, predRest)("a"), false, "Not an array");
     assertEquals(
-      isTupleOf(predTup, predRest)([0, "a", true, 0, 0, 1, 2]),
+      isTupleOf(predTup, predRest)([0, "a"]),
       false,
+      "Less than `predTup.length`",
     );
-    assertEquals(isTupleOf(predTup, predRest)([0, "a", true, 0, 1, 2]), false);
+    assertEquals(
+      isTupleOf(predTup, predRest)([0, 1, 2]),
+      false,
+      "Not match `predTup` and no rest elements",
+    );
+    assertEquals(
+      isTupleOf(predTup, predRest)([0, 1, 2, 0, 1, 2]),
+      false,
+      "Not match `predTup` and `predRest`",
+    );
+    assertEquals(
+      isTupleOf(predTup, predRest)([0, "a", true, 0, 1, 2]),
+      false,
+      "Match `predTup` but not match `predRest`",
+    );
+    assertEquals(
+      isTupleOf(predTup, predRest)([0, "a", "b", "a", "b", "c"]),
+      false,
+      "Match `predRest` but not match `predTup`",
+    );
   });
 
   await t.step("predicated type is correct", () => {

--- a/is/tuple_of_test.ts
+++ b/is/tuple_of_test.ts
@@ -317,13 +317,13 @@ Deno.test("isTupleOf<T, R, L>", async (t) => {
   await t.step("predicated type is correct", () => {
     const predTup = [is.Number, is.String, is.Boolean] as const;
     const predRest = is.ArrayOf(is.Number);
-    const predTrail = [is.Number, is.String, is.Boolean] as const;
-    const a: unknown = [0, "a", true, 0, 1, 2, 0, "a", true];
+    const predTrail = [is.Number, is.Boolean] as const;
+    const a: unknown = [0, "a", true, 0, 1, 2, 0, true];
     if (isTupleOf(predTup, predRest, predTrail)(a)) {
       assertType<
         Equal<
           typeof a,
-          [number, string, boolean, ...number[], number, string, boolean]
+          [number, string, boolean, ...number[], number, boolean]
         >
       >(
         true,

--- a/is/tuple_of_test.ts
+++ b/is/tuple_of_test.ts
@@ -66,7 +66,7 @@ Deno.test("isTupleOf<T, R>", async (t) => {
           [
             isTupleOf(
               [is.Number, is.String, is.Boolean],
-              is.Array,
+              is.ArrayOf(is.String),
             ),
           ],
           is.Array,
@@ -143,7 +143,12 @@ Deno.test("isTupleOf<R, T>", async (t) => {
       isTupleOf([
         isTupleOf(
           is.Array,
-          [isTupleOf(is.Array, [is.Number, is.String, is.Boolean])],
+          [
+            isTupleOf(
+              is.ArrayOf(is.String),
+              [is.Number, is.String, is.Boolean],
+            ),
+          ],
         ),
       ]).name,
     );
@@ -206,7 +211,7 @@ Deno.test("isTupleOf<T, R, L>", async (t) => {
       isTupleOf(
         [is.Number, is.String, is.Boolean],
         is.Array,
-        [is.Number, is.String, is.Boolean],
+        [is.String, is.Boolean, is.Number],
       ).name,
     );
     await assertSnapshot(
@@ -224,14 +229,16 @@ Deno.test("isTupleOf<T, R, L>", async (t) => {
           [
             isTupleOf(
               [is.Number, is.String, is.Boolean],
-              is.Array,
+              is.ArrayOf(is.String),
+              [is.String, is.Boolean, is.Number],
             ),
           ],
           is.Array,
           [
             isTupleOf(
               [is.Number, is.String, is.Boolean],
-              is.Array,
+              is.ArrayOf(is.Number),
+              [is.Number, is.Boolean, is.String],
             ),
           ],
         ),


### PR DESCRIPTION
Typescript tuple types can define leading or middle rest elements.
Added corresponding overloads to `isTupleOf()`.